### PR TITLE
Fix field lookup

### DIFF
--- a/src/main/java/com/example/LoxInstance.java
+++ b/src/main/java/com/example/LoxInstance.java
@@ -17,7 +17,7 @@ public class LoxInstance {
     }
 
     Object get(Token name) {
-        if (fields.containsValue(name.lexeme)) {
+        if (fields.containsKey(name.lexeme)) {
             return fields.get(name.lexeme);
         }
 

--- a/src/test/java/com/example/LoxInstanceTest.java
+++ b/src/test/java/com/example/LoxInstanceTest.java
@@ -1,0 +1,24 @@
+package com.example;
+
+import java.util.HashMap;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class LoxInstanceTest extends TestCase {
+    public LoxInstanceTest(String testName) {
+        super(testName);
+    }
+
+    public static Test suite() {
+        return new TestSuite(LoxInstanceTest.class);
+    }
+
+    public void testFieldAccess() {
+        LoxClass klass = new LoxClass("Foo", null, new HashMap<>());
+        LoxInstance instance = new LoxInstance(klass);
+        Token token = new Token(Token.TokenType.IDENTIFIER, "bar", null, 1);
+        instance.set(token, 42);
+        assertEquals(42, instance.get(token));
+    }
+}


### PR DESCRIPTION
## Summary
- fix field lookup check in LoxInstance
- add regression test for instance field access

## Testing
- `mvn test` *(fails: `mvn: command not found`)*